### PR TITLE
ci: add merge_group support and broaden pull_request triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,17 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
+      - reopened
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 jobs:
   lint:
     name: Lint
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,7 +43,7 @@ jobs:
 
   typecheck:
     name: Typecheck
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -67,7 +72,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -96,7 +101,7 @@ jobs:
 
   build:
     name: Build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- add `merge_group` trigger (`checks_requested`) to CI workflow
- run `lint`, `typecheck`, `unit-tests`, and `build` for both `pull_request` and `merge_group`
- expand `pull_request` trigger types to include `opened`, `synchronize`, and `reopened`

## Why
This ensures required checks run for merge queue and for PR updates/reopens, reducing merge-queue surprises and missed CI runs.

## Test plan
- [ ] Open/update/reopen a PR and confirm CI runs
- [ ] Queue PR in merge queue and confirm `merge_group` checks run
- [ ] Manually verify `e2e-tests` remains `workflow_dispatch` only